### PR TITLE
FAQ: remove the claim that the FSF thinks free software is different

### DIFF
--- a/_includes/faq.html
+++ b/_includes/faq.html
@@ -46,7 +46,7 @@
         <p>
             <question>Q: You clearly have no idea what free software is about.</question>
             <answer>
-                A: Maybe, but I'm more interested in open source software anyway (The FSF makes a distinction here).
+                A: Maybe, but I'm more interested in open source software anyway. It's the same thing, but without the FSF bullshit nomenclature.
                 I'm also not interested in politics. Just technology and how to improve it.<br/>
                 A nice quote from Linus Torvalds:<br/>
                 <br/>


### PR DESCRIPTION
The FSF doesn't think free software is different than open source,
except for the tinest fraction:

    https://www.gnu.org/philosophy/free-open-overlap.html

Open source was coined as a synonym for free software:

    http://jordi.inversethought.com/blog/5-things-we-have-forgotten-about-open-source/

The FSF is the one that insists the most on the "free software" thing,
but huge GPL haters and old timers like OpenBSD also call what they're
doing free software:

    This release, instead of bemoaning vendors or organizations that
    try to make our task of writing free software more difficult, we
    instead celebrate the 10 years that we have been given (so far) to
    write free software, express our themes in art, and the 5 years
    that we have made music with a group of talented musicians.

http://www.openbsd.org/lyrics.html#40
